### PR TITLE
implement the withdraw

### DIFF
--- a/dapps/OptractMedia/Conditions/OptractMedia/BlockRegistry/Sanity.js
+++ b/dapps/OptractMedia/Conditions/OptractMedia/BlockRegistry/Sanity.js
@@ -40,15 +40,11 @@ module.exports =
 	{
 		return true;
 	},
+        BlockRegistry_verifySignatureWithPrefix_sanity(addr, jobObj)
+	{
+		return true;
+	},
         BlockRegistry_merkleTreeValidator_sanity(addr, jobObj)
-	{
-		return true;
-	},
-        BlockRegistry_calcLeaf_sanity(addr, jobObj)
-	{
-		return true;
-	},
-        BlockRegistry_calcLeaf2_sanity(addr, jobObj)
 	{
 		return true;
 	},

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -1076,61 +1076,79 @@ class OptractNode extends PubSubNode {
 			})
 		}
 
-                this.withdraw = (opround, v1block, v1leaf, v2block, v2leaf, claimBlock, claimTxhash) => {  // previous name: claimReward
-                        // function withdraw(
-                        //     bytes32[6] calldata b32s, uint[5] calldata uints,
-                        //     bytes32[] calldata claimProof, bytes32[] calldata proof1, bytes32[] calldata proof2,
-                        //     uint24[3] calldata uintIsLeft,
-                        //     uint8 _v
-                        // ) external returns(bool) {
-                        //     // note: v1 is vote by the user in _opRound, v2 is the article used for claim
-                        //     // note: "b32s" and "uints" are also used in "verifySignatureWithPrefix()" and "genV2Txhash()":
-                        //     //     b32s = [_comment, v1leaf, v2leaf, _payload, _r, _s]
-                        //     //     uints = [_opRound, v1block, v2block, claimBlock, since]
-                        //     //     uintIsLeft =  [claimIsLeft, v1IsLeft, v2IsLeft]
+		this.withdraw = (opround, v1block, v1leaf, v2block, v2leaf, claimBlock, claimLeaf) => {
+			// Note about prefix or suffix of arguments:
+			// * `v1*` is the article voted by the user
+			// * `v2*` is the article the user used to claim
+			// * others are about the newClaim() transaction itself
 
-                        // Note about variable prefix or suffix:
-                        // * `v1` or `1` is the article voted by the user
-                        // * `v2` or `2` is the article the user used to claim
-                        // * `claim` or without prefix/suffix ones are about the newClaim() transaction
-                        let p = [ 
-                                    this.getProofSet(v1block, v1leaf),
-                                    this.getProofSet(v2block, v2leaf),
-                                    this.getProofSet(claimBlock, claimTxhash),
-                                    this.locateTx(claimBlock)(claimTxhash, 'payloadvrs')
-                                ];
+			// function withdraw(
+			//     bytes32[6] calldata b32s, uint[5] calldata uints,
+			//     bytes32[] calldata claimProof, bytes32[] calldata proof1, bytes32[] calldata proof2,
+			//     uint24[3] calldata uintIsLeft,
+			//     uint8 _v
+			// ) external returns(bool) {
+			//     // note: v1 is vote by the user in _opRound, v2 is the article used for claim
+			//     // note: "b32s" and "uints" are also used in "verifySignatureWithPrefix()" and "genV2Txhash()":
+			//     //     b32s = [_comment, v1leaf, v2leaf, _payload, _r, _s]
+			//     //     uints = [_opRound, v1block, v2block, claimBlock, since]
+			//     //     uintIsLeft =  [claimIsLeft, v1IsLeft, v2IsLeft]
+			let p = [ 
+				    this.getProofSet(v1block, v1leaf),
+				    this.getProofSet(v2block, v2leaf),
+				    this.getProofSet(claimBlock, claimLeaf),
+				    this.locateTx(claimBlock)(claimLeaf, 'payloadvrs')
+				];
+			const sideToInt = ((side) => {
+				return side.map((v, k)=>{
+					return v===true ? 2**(side.length-1-k) : 0
+				}).reduce((_a, _b)=> _a+_b)
+			});
 			return Promise.all(p).then((rc)=>{
+			        // for the components of the newClaim tx
 				let v1proof = rc[0][0];
-				let v1isLeft = rc[0][1];
+				let v1side = rc[0][1];
+				v1side = sideToInt(v1side);
 				let v2proof = rc[1][0];
-				let v2isLeft = rc[1][1];
+				let v2side = rc[1][1];
+				v2side = sideToInt(v2side);
 
+                                // newClaim tx itself
 				let proof = rc[2][0];
-				let isLeft = rc[2][1];
+				let side = rc[2][1];
+				side = sideToInt(side);
 				let payload = rc[3][0];
 				let v = rc[3][1];
 				let r = rc[3][2];
 				let s = rc[3][3];
-                                let comment = rc[3][4];
-                                let since = rc[3][5];
+				let comment = rc[3][4];
+				let since = rc[3][5];
 
-				// check before send
-				// this.call(this.appName)('BlockRegistry')('verifySignature')(this.userWallet[this.appName], payload, v, r, s).then(()=>{})
-			        let b32s = [comment, v1leaf, v2leaf, payload, r, s];
-                                let uints = [opround, v1block, v2block, claimBlock, since];
-                                let uintIsLeft = [isLeft, v1IsLeft, v2IsLeft];
+				// group the arguments for smart contract
+				let b32s = [comment, v1leaf, v2leaf, payload, r, s];
+				let uints = [opround, v1block, v2block, claimBlock, since];
+				let uintIsLeft = [side, v1side, v2side];
+				// console.log('DEBUG: arguments for withdraw ')
+				// console.log(b32s)
+				// console.log(uints)
+				// console.log(proof)
+				// console.log(v1proof)
+				// console.log(v2proof)
+				// console.log(uintIsLeft)
+				// console.log(v)
 
-			        console.log('DEBUG: arguments for withdraw ')
-			        console.log(b32s)
-			        console.log(uints)
-			        console.log(proof)
-			        console.log(v1proof)
-			        console.log(v2proof)
-			        console.log(uintIsLeft)
-			        console.log(v)
-			        return
-				// return this.sendTk(this.appName)('BlockRegistry')('withdraw')(b32s, uints, proof, v1proof1, v2proof, uintIsLeft, v)();
+				// verify then send
+				return this.call(this.appName)('BlockRegistry')('verifySignatureWithPrefix')(this.userWallet[this.appName], b32s, v).then((yn)=>{
+					// TODO: contract also check: txExist of 3 leaves, isWinningTicket v1, isWinningTicket v2,
+					//       v1block is before lottery, v2block is after lottery, current opRound not too far
+					//       from the withdraw (<16 opround difference)
+					if (yn === true) {
+						return this.sendTk(this.appName)('BlockRegistry')('withdraw')(
+						    b32s, uints, proof, v1proof, v2proof, uintIsLeft, v)();
+					}
+				})
 			})
+			.catch((err) => { console.trace(err); })
 		}
 
 		this.rssParser = new Parser();
@@ -2451,13 +2469,13 @@ class OptractNode extends PubSubNode {
 								let bksnap = JSON.parse(bd.toString()).data;
 								// this.pinBlockDelta(bksnap, bksnap[0]);
 								let i = bksnap[0].indexOf(txhash); // assuming already pass merkle check
-                                                                let payload = ethUtils.bufferToHex(bksnap[1][i].data);
+								let payload = ethUtils.bufferToHex(bksnap[1][i].data);
 								let txdata = this.parseMsgRLPx(Buffer.from(bksnap[2][i]));
-							        let v = ethUtils.bufferToInt(txdata.v);
-							        let r = ethUtils.bufferToHex(txdata.r);
-							        let s = ethUtils.bufferToHex(txdata.s);
-							        let comment = ethUtils.bufferToHex(txdata.comment);
-							        let since = ethUtils.bufferToHex(txdata.since);
+								let v = ethUtils.bufferToInt(txdata.v);
+								let r = ethUtils.bufferToHex(txdata.r);
+								let s = ethUtils.bufferToHex(txdata.s);
+								let comment = ethUtils.bufferToHex(txdata.comment);
+								let since = ethUtils.bufferToInt(txdata.since);
 								resolve([payload, v, r, s, comment, since]);
 							})
 						})


### PR DESCRIPTION
The recent deployed smart contract (7a9745a) rename the original `claimReward()` function into `withdraw()` and also add a lot of inputs in order to verify whether the user is qualified to withdraw or not. These have been implemented in this pull request, although still need to use a real data for test.